### PR TITLE
remove scrollbar in div.div1

### DIFF
--- a/Felipe_webpage_style.css
+++ b/Felipe_webpage_style.css
@@ -28,7 +28,7 @@
     text-align:center;
     padding: 10px;
     border: 3px solid #000000;
-    overflow: auto;
+    overflow: hidden;
 }
 .div2 {
     margin:0 auto;


### PR DESCRIPTION
I noticed how in your description you have a scrolling bar. I saw that you tried to fix the position of your content hence why you added 'overflow: auto' but it added a scrolling bar which was unnecessary so if you do 'overflow: hidden' then you will remove that pesky scrollbar. 

Also I would recommend you to add more semantic tags! There's header, nav, main, article, section, footer. All those goodies!
https://www.w3schools.com/Html/html5_semantic_elements.asp 
You could read more in there.